### PR TITLE
Fix exit crashes on Windows (Rack v2.4.0)

### DIFF
--- a/src/Sequel16.cpp
+++ b/src/Sequel16.cpp
@@ -402,7 +402,7 @@ struct Sequel16 : Module {
 	dsp::PulseGenerator gatePulseR1;
 	dsp::PulseGenerator gatePulseR2;
 
-	SequelClockTracker clockTracker{16};
+	SequelClockTracker clockTracker {16,16};
 
 	bool gateTriggerModeEnabled = true;
 

--- a/src/Sequel8.cpp
+++ b/src/Sequel8.cpp
@@ -258,7 +258,7 @@ struct Sequel8 : Module {
 	dsp::PulseGenerator gatePulseR1;
 	dsp::PulseGenerator gatePulseR2;
 
-	SequelClockTracker clockTracker{8};
+	SequelClockTracker clockTracker {8,8};
 
 	bool gateTriggerModeEnabled = true;
 	

--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -234,7 +234,7 @@ struct SequelClockTracker {
 		short numRows = 3
 	) {
         numSteps = initializeNumSteps;
-		numRows = numRows;
+		this->numRows = numRows;
 
 		for(int i = 0; i < numRows; i++) {
 			currentStepTracker.push_back(0);


### PR DESCRIPTION
Deleting Sequel8/16 or exiting Rack with modules in patch crashes.
```
Thread 1 received signal SIGTRAP, Trace/breakpoint trap.
0x00007fff82fea4e3 in ntdll!RtlRegisterSecureMemoryCacheCallback () from C:\WINDOWS\SYSTEM32\ntdll.dll
(gdb) bt
#0  0x00007fff82fea4e3 in ntdll!RtlRegisterSecureMemoryCacheCallback () from C:\WINDOWS\SYSTEM32\ntdll.dll
#1  0x00007fff82fe6b6f in ntdll!RtlZeroHeap () from C:\WINDOWS\SYSTEM32\ntdll.dll
#2  0x00007fff82faceda in ntdll!memset () from C:\WINDOWS\SYSTEM32\ntdll.dll
#3  0x00007fff82fe9391 in ntdll!RtlRegisterSecureMemoryCacheCallback () from C:\WINDOWS\SYSTEM32\ntdll.dll
#4  0x00007fff82f15cc1 in ntdll!RtlGetCurrentServiceSessionId () from C:\WINDOWS\SYSTEM32\ntdll.dll
#5  0x00007fff82f15b74 in ntdll!RtlGetCurrentServiceSessionId () from C:\WINDOWS\SYSTEM32\ntdll.dll
#6  0x00007fff82f147b1 in ntdll!RtlFreeHeap () from C:\WINDOWS\SYSTEM32\ntdll.dll
#7  0x00007fff80f69c9c in msvcrt!free () from C:\WINDOWS\System32\msvcrt.dll
#8  0x00007fff43680c60 in std::__new_allocator<short>::deallocate (this=<optimized out>, __p=0x7fff82f0ead2 <ntdll!RtlGetFullPathName_UstrEx+4674>, __n=364)
    at C:/msys64/mingw64/include/c++/13.2.0/bits/new_allocator.h:168
#9  0x00007fff4367f67f in std::allocator_traits<std::allocator<short> >::deallocate (__n=364, __p=0x7fff82f0ead2 <ntdll!RtlGetFullPathName_UstrEx+4674>, __a=...)
    at C:/msys64/mingw64/include/c++/13.2.0/bits/alloc_traits.h:515
#10 std::_Vector_base<short, std::allocator<short> >::_M_deallocate (__n=364, __p=0x7fff82f0ead2 <ntdll!RtlGetFullPathName_UstrEx+4674>, this=0xcd5180594a2c0000)
    at C:/msys64/mingw64/include/c++/13.2.0/bits/stl_vector.h:387
#11 std::_Vector_base<short, std::allocator<short> >::~_Vector_base (this=0xcd5180594a2c0000, __in_chrg=<optimized out>)
    at C:/msys64/mingw64/include/c++/13.2.0/bits/stl_vector.h:366
#12 0x00007fff43681e4d in std::vector<short, std::allocator<short> >::~vector (this=0xcd5180594a2c0000, this@entry=0x11acaca0, __in_chrg=<optimized out>)
    at C:/msys64/mingw64/include/c++/13.2.0/bits/alloc_traits.h:944
#13 0x00007fff43664449 in SequelClockTracker::~SequelClockTracker (this=this@entry=0x11acac80, __in_chrg=<optimized out>) at src/plugin.hpp:230
#14 0x00007fff43678354 in Sequel16::~Sequel16 (this=this@entry=0x11aca750, __in_chrg=<optimized out>) at src/Sequel16.cpp:6
#15 0x00007fff43678313 in Sequel16::~Sequel16 (this=0x11aca750, __in_chrg=<optimized out>) at src/Sequel16.cpp:6
#16 0x00007fff4903a775 in rack::app::ModuleWidget::setModule (module=0x0, this=0x7ac6ee0) at src/app/ModuleWidget.cpp:70
#17 rack::app::ModuleWidget::~ModuleWidget (this=this@entry=0x7ac6ee0, __in_chrg=<optimized out>) at src/app/ModuleWidget.cpp:50
#18 0x00007fff4366309d in Sequel16Widget::~Sequel16Widget (this=0x7ac6ee0, __in_chrg=<optimized out>) at src/Sequel16.cpp:699
#19 Sequel16Widget::~Sequel16Widget (this=0x7ac6ee0, __in_chrg=<optimized out>) at src/Sequel16.cpp:699
#20 0x00007fff490520ec in rack::app::RackWidget::clear (this=0x73a3d90) at src/app/RackWidget.cpp:238
#21 0x00007fff490521ff in rack::app::RackWidget::~RackWidget (this=0x73a3d90, __in_chrg=<optimized out>) at src/app/RackWidget.cpp:117
#22 rack::app::RackWidget::~RackWidget (this=0x73a3d90, __in_chrg=<optimized out>) at src/app/RackWidget.cpp:119
#23 0x00007fff49075b05 in rack::widget::Widget::clearChildren (this=0x75a60a8, this@entry=0x71c82a0) at src/widget/Widget.cpp:243
#24 0x00007fff49075b36 in rack::widget::Widget::~Widget (this=this@entry=0x71c82a0, __in_chrg=<optimized out>) at src/widget/Widget.cpp:14
#25 0x00007fff494c89bd in rack::widget::ZoomWidget::~ZoomWidget (this=0x71c82a0, __in_chrg=<optimized out>) at include/widget/ZoomWidget.hpp:10
#26 rack::widget::ZoomWidget::~ZoomWidget (this=0x71c82a0, __in_chrg=<optimized out>) at include/widget/ZoomWidget.hpp:10
#27 0x00007fff49075b05 in rack::widget::Widget::clearChildren (this=0x14f960, this@entry=0x75a6080) at src/widget/Widget.cpp:243
#28 0x00007fff49075a5d in rack::widget::Widget::~Widget (this=0x75a6080, __in_chrg=<optimized out>) at src/widget/Widget.cpp:14
#29 rack::widget::Widget::~Widget (this=0x75a6080, __in_chrg=<optimized out>) at src/widget/Widget.cpp:15
#30 rack::widget::Widget::clearChildren (this=0x752abc8, this@entry=0x6353c00) at src/widget/Widget.cpp:243
#31 0x00007fff49075b36 in rack::widget::Widget::~Widget (this=this@entry=0x6353c00, __in_chrg=<optimized out>) at src/widget/Widget.cpp:14
```