### PR TITLE
Exit crashes - fix last PR

### DIFF
--- a/src/Sequel16.cpp
+++ b/src/Sequel16.cpp
@@ -402,7 +402,7 @@ struct Sequel16 : Module {
 	dsp::PulseGenerator gatePulseR1;
 	dsp::PulseGenerator gatePulseR2;
 
-	SequelClockTracker clockTracker {16,16};
+	SequelClockTracker clockTracker {16,3};
 
 	bool gateTriggerModeEnabled = true;
 

--- a/src/Sequel8.cpp
+++ b/src/Sequel8.cpp
@@ -258,7 +258,7 @@ struct Sequel8 : Module {
 	dsp::PulseGenerator gatePulseR1;
 	dsp::PulseGenerator gatePulseR2;
 
-	SequelClockTracker clockTracker {8,8};
+	SequelClockTracker clockTracker {8,3};
 
 	bool gateTriggerModeEnabled = true;
 	


### PR DESCRIPTION
Oops sorry, noticed mistake with ```numRows``` should be 3 not 8 or 16 i.e. ```{8 or 16, 3}```